### PR TITLE
Tweak README.md for proper header rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ To see a brief demonstration for the Attack Surface Detector, you can check it o
 1. For Build/install instructions click [here:](https://github.com/secdec/attack-surface-detector-zap/wiki)
 
 
-##License
+## License
 
 Licensed under the [MPL](https://github.com/secdec/attack-surface-detector-zap/blob/master/LICENSE) License.


### PR DESCRIPTION
Add a space in the License header for proper rendering of the Markdown.