### PR TITLE
Remove filters element from add-on manifest

### DIFF
--- a/zaproxy/src/org/zaproxy/zap/extension/attacksurfacedetector/resources-filtered/ZapAddOn.xml
+++ b/zaproxy/src/org/zaproxy/zap/extension/attacksurfacedetector/resources-filtered/ZapAddOn.xml
@@ -16,7 +16,6 @@
     </extensions>
     <ascanrules/>
     <pscanrules/>
-    <filters/>
     <files></files>
     <not-before-version>${zap.addon.not-before-version}</not-before-version>
     <not-from-version></not-from-version>


### PR DESCRIPTION
The filter functionality is deprecated and will stop working in the next
ZAP version.

Ref: zaproxy/zaproxy#4191.