### PR TITLE
Bump ZAP version and use `ZapHtmlLabel`

### DIFF
--- a/zaproxy/pom.xml
+++ b/zaproxy/pom.xml
@@ -316,7 +316,7 @@
         <dependency>
             <groupId>org.zaproxy</groupId>
             <artifactId>zap</artifactId>
-            <version>2.7.0</version>
+            <version>2.12.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/zaproxy/src/org/zaproxy/zap/extension/attacksurfacedetector/AttackSurfaceDetectorPanel.java
+++ b/zaproxy/src/org/zaproxy/zap/extension/attacksurfacedetector/AttackSurfaceDetectorPanel.java
@@ -70,6 +70,7 @@ import org.apache.log4j.Logger;
 import org.parosproxy.paros.extension.AbstractPanel;
 import org.parosproxy.paros.extension.ViewDelegate;
 import org.parosproxy.paros.model.Model;
+import org.zaproxy.zap.utils.ZapHtmlLabel;
 
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
@@ -786,7 +787,7 @@ public class AttackSurfaceDetectorPanel extends AbstractPanel
 
                     JPanel detailPanel = new JPanel();
                     detailPanel.setLayout(new GridBagLayout());
-                    JLabel displayArea = new JLabel();
+                    JLabel displayArea = new ZapHtmlLabel();
                     String displayStr = new String();
                     int y = 0;
                     GridBagConstraints gridBagConstraints1 = new GridBagConstraints();
@@ -984,7 +985,7 @@ public class AttackSurfaceDetectorPanel extends AbstractPanel
 
     private JLabel addPanelDescriptionToGridBagLayout(String descriptionText, Container gridBagContainer, int yPosition)
     {
-        final JLabel panelDescription = new JLabel(descriptionText);
+        final JLabel panelDescription = new ZapHtmlLabel(descriptionText);
         panelDescription.setHorizontalAlignment(SwingConstants.LEFT);
         GridBagConstraints gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridwidth = 3;

--- a/zaproxy/src/org/zaproxy/zap/extension/attacksurfacedetector/resources-filtered/ZapAddOn.xml
+++ b/zaproxy/src/org/zaproxy/zap/extension/attacksurfacedetector/resources-filtered/ZapAddOn.xml
@@ -8,7 +8,7 @@
     <changes>
         <![CDATA[
         Various incremental changes (see https://github.com/secdec/attack-surface-detector-zap/releases)<br>
-        Fix un-handled exception when target unavailable & address various "house keeping" tasks.<br>
+        Properly display HTML content in GUI.<br>
         ]]>
     </changes>
     <extensions>


### PR DESCRIPTION
Bump ZAP version to 2.12.
Use `ZapHtmlLabel` to display HTML content.

Fix #26.